### PR TITLE
Fix a few static analysis warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: erlang
 otp_release:
-  - 19.2
+  - 19.3
   - 18.3
 before_install:
   - ./ci before_install "${PWD:?}"/rebar3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.2.4](https://github.com/inaka/cowboy_swagger/tree/1.2.4) (2019-02-21)
+[Full Changelog](https://github.com/inaka/cowboy_swagger/compare/1.2.3...1.2.4)
+
+**Merged pull requests:**
+
+ - Fix unknown type cowboy_route:route_match, via cowboy-trails, + static analysis [\#116](https://github.com/inaka/cowboy_swagger/pull/116) ([paulo-ferraz-oliveira](https://github.com/paulo-ferraz-oliveira)) 
+
 ## [1.2.3](https://github.com/inaka/cowboy_swagger/tree/1.2.3) (2017-06-13)
 [Full Changelog](https://github.com/inaka/cowboy_swagger/compare/1.2.2...1.2.3)
 

--- a/rebar.config
+++ b/rebar.config
@@ -69,13 +69,27 @@
 {dialyzer, [ {warnings, [ no_return
                         , unmatched_returns
                         , error_handling
+                        , underspecs
+                        , unknown
                         ]}
            , {plt_apps, top_level_deps}
-           , {plt_extra_apps, []}
+           , {plt_extra_apps, [cowboy, cowlib, ranch]}
            , {plt_location, local}
-           , {base_plt_apps, [stdlib, kernel]}
+           , {base_plt_apps, [erts, stdlib, kernel]}
            , {base_plt_location, global}]}.
 
+
+%% == xref ==
+
+{xref_warnings, true}.
+{xref_checks,
+  [
+    undefined_function_calls
+  , locals_not_used
+  , deprecated_function_calls
+  , deprecated_functions
+  ]
+}.
 
 %% == Shell ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -61,7 +61,7 @@
 %% == Dependencies ==
 
 {deps, [ {jsx, "2.8.1"}
-       , {trails, "0.2.1"}
+       , {trails, "0.2.2"}
        ]}.
 
 %% == Dialyzer ==

--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,6 @@
 {dialyzer, [ {warnings, [ no_return
                         , unmatched_returns
                         , error_handling
-                        , underspecs
                         , unknown
                         ]}
            , {plt_apps, top_level_deps}

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,14 +1,16 @@
 {"1.1.0",
-[{<<"cowboy">>,{pkg,<<"cowboy">>,<<"1.0.4">>},1},
+[{<<"cowboy">>,{pkg,<<"cowboy">>,<<"1.1.2">>},1},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"1.0.2">>},2},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.1">>},0},
- {<<"ranch">>,{pkg,<<"ranch">>,<<"1.2.1">>},1},
- {<<"trails">>,{pkg,<<"trails">>,<<"0.2.1">>},0}]}.
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
+ {<<"ranch">>,{pkg,<<"ranch">>,<<"1.3.2">>},1},
+ {<<"trails">>,{pkg,<<"trails">>,<<"0.2.2">>},0}]}.
 [
 {pkg_hash,[
- {<<"cowboy">>, <<"A324A8DF9F2316C833A470D918AAF73AE894278B8AA6226CE7A9BF699388F878">>},
+ {<<"cowboy">>, <<"61AC29EA970389A88ECA5A65601460162D370A70018AFE6F949A29DCA91F3BB0">>},
  {<<"cowlib">>, <<"9D769A1D062C9C3AC753096F868CA121E2730B9A377DE23DEC0F7E08B1DF84EE">>},
  {<<"jsx">>, <<"1453B4EB3615ACB3E2CD0A105D27E6761E2ED2E501AC0B390F5BBEC497669846">>},
- {<<"ranch">>, <<"A6FB992C10F2187B46FFD17CE398DDF8A54F691B81768F9EF5F461EA7E28C762">>},
- {<<"trails">>, <<"6769F7A2B777EC9CEAF07F22C23E5F3BE6A7F07E9A11B44725B102A832334D46">>}]}
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"ranch">>, <<"E4965A144DC9FBE70E5C077C65E73C57165416A901BD02EA899CFD95AA890986">>},
+ {<<"trails">>, <<"9202FF18BDC540F1F96D4B813C01CB019CCD16C141FC4C0F0DE735E4E7DC01B5">>}]}
 ].

--- a/src/cowboy_swagger.app.src
+++ b/src/cowboy_swagger.app.src
@@ -2,7 +2,7 @@
  [
   {description,
    "Swagger for Cowboy Erlang projects"},
-  {vsn, "1.2.3"},
+  {vsn, "1.2.4"},
   {applications,
    [kernel,
     stdlib,

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -90,9 +90,9 @@ add_definition(Name, Properties) ->
   application:set_env(cowboy_swagger, global_spec, NewSpec).
 
 -spec schema(DefinitionName::parameter_definition_name()) ->
-  map().
+  #{binary() => binary()}.
 schema(DefinitionName) ->
-  #{<<"$ref">> => <<"#/definitions/", DefinitionName/binary>>}.
+  #{<<<<"$ref">>/binary>> => <<<<"#/definitions/">>/binary, DefinitionName/binary>>}.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -92,7 +92,7 @@ add_definition(Name, Properties) ->
 -spec schema(DefinitionName::parameter_definition_name()) ->
   #{binary() => binary()}.
 schema(DefinitionName) ->
-  #{<<<<"$ref">>/binary>> => <<<<"#/definitions/">>/binary, DefinitionName/binary>>}.
+  #{<<"$ref">> => <<"#/definitions/", DefinitionName/binary>>}.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This version will fail on OTP 20, though, due to the use of an _old_ `cowlib` version.

Warning is `call to crypto:rand_bytes/1 will fail, since it was removed in 20.0; use crypto:strong_rand_bytes/1`