### PR TITLE
New function add_definition_array/2 in cowboy_swagger

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -42,6 +42,13 @@
       #{ type => binary()
        , properties => property_obj()
        }}.
+-type parameters_definition_array() ::
+  #{parameter_definition_name() =>
+      #{ type => binary()
+       , items => #{ type => binary()
+                   , properties => property_obj()
+                   }
+       }}.
 -export_type([parameter_definition_name/0, property_obj/0]).
 
 %% Swagger map spec
@@ -90,7 +97,9 @@ add_definition(Name, Properties) ->
   Definition = build_definition(Name, Properties),
   add_definition(Definition).
 
--spec add_definition( Definition :: parameters_definitions()) ->
+-spec add_definition( Definition :: parameters_definitions()
+                                  | parameters_definition_array()
+                    ) ->
   ok.
 add_definition(Definition) ->
   CurrentSpec = application:get_env(cowboy_swagger, global_spec, #{}),
@@ -242,7 +251,7 @@ build_definition(Name, Properties) ->
 -spec build_definition_array( Name::parameter_definition_name()
                             , Properties::property_obj()
                             ) ->
-  parameters_definitions().
+  parameters_definition_array().
 build_definition_array(Name, Properties) ->
   #{Name => #{ type => <<"array">>
              , items => #{ type => <<"object">>

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -2,7 +2,7 @@
 -module(cowboy_swagger).
 
 %% API
--export([to_json/1, add_definition/2, schema/1]).
+-export([to_json/1, add_definition/2, add_definition_array/2, schema/1]).
 
 %% Utilities
 -export([enc_json/1, dec_json/1]).
@@ -74,12 +74,25 @@ to_json(Trails) ->
   SwaggerSpec = create_swagger_spec(GlobalSpec, SanitizeTrails),
   enc_json(SwaggerSpec).
 
+-spec add_definition_array( Name::parameter_definition_name()
+                          , Properties::property_obj()
+                          ) ->
+  ok.
+add_definition_array(Name, Properties) ->
+  DefinitionArray = build_definition_array(Name, Properties),
+  add_definition(DefinitionArray).
+
 -spec add_definition( Name::parameter_definition_name()
                     , Properties::property_obj()
                     ) ->
   ok.
 add_definition(Name, Properties) ->
   Definition = build_definition(Name, Properties),
+  add_definition(Definition).
+
+-spec add_definition( Definition :: parameters_definitions()) ->
+  ok.
+add_definition(Definition) ->
   CurrentSpec = application:get_env(cowboy_swagger, global_spec, #{}),
   ExistingDefinitions = maps:get(definitions, CurrentSpec, #{}),
   NewSpec = CurrentSpec#{definitions => maps:merge( ExistingDefinitions
@@ -224,3 +237,16 @@ build_definition(Name, Properties) ->
   #{Name => #{ type => <<"object">>
              , properties => Properties
              }}.
+
+%% @private
+-spec build_definition_array( Name::parameter_definition_name()
+                            , Properties::property_obj()
+                            ) ->
+  parameters_definitions().
+build_definition_array(Name, Properties) ->
+  #{Name => #{ type => <<"array">>
+             , items => #{ type => <<"object">>
+                         , properties => Properties
+                         }
+             }}.
+

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -49,7 +49,11 @@
                    , properties => property_obj()
                    }
        }}.
--export_type([parameter_definition_name/0, property_obj/0]).
+-export_type([ parameter_definition_name/0
+             , property_obj/0
+             , parameters_definitions/0
+             , parameters_definition_array/0
+             ]).
 
 %% Swagger map spec
 -opaque swagger_map() ::

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -10,7 +10,9 @@
 
 -export([all/0]).
 -export([ to_json_test/1
-        , add_definition_test/1]).
+        , add_definition_test/1
+        , add_definition_array_test/1
+        ]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Common test
@@ -136,40 +138,62 @@ to_json_test(_Config) ->
 -spec add_definition_test(Config::cowboy_swagger_test_utils:config()) ->
   {comment, string()}.
 add_definition_test(_Config) ->
+  %%
+  %% Given
+  %%
   ct:comment("Add first definition"),
   Name1 = <<"CostumerDefinition">>,
-  Properties1 =
-    #{ <<"first_name">> =>
-        #{ type => <<"string">>
-         , description => <<"User first name">>
-         , example => <<"Pepito">>
-         }
-    , <<"last_name">> =>
-        #{ type => <<"string">>
-         , description => <<"User last name">>
-         , example => <<"Perez">>
-         }
-    },
-  ok = cowboy_swagger:add_definition(Name1, Properties1),
+  Properties1 = test_properties_one(),
 
   ct:comment("Add second definition"),
   Name2 = <<"CarDefinition">>,
-  Properties2 =
-    #{ <<"brand">> =>
-        #{ type => <<"string">>
-         , description => <<"Car brand">>
-         }
-    , <<"year">> =>
-        #{ type => <<"string">>
-         , description => <<"Production time">>
-         , example => <<"1995">>
-         }
-    },
+  Properties2 = test_properties_two(),
+
+  %%
+  %% When
+  %%
+  ok = cowboy_swagger:add_definition(Name1, Properties1),
   ok = cowboy_swagger:add_definition(Name2, Properties2),
+
+  %%
+  %% Then
+  %%
   {ok, SwaggerSpec1} = application:get_env(cowboy_swagger, global_spec),
   JsonDefinitions = maps:get(definitions, SwaggerSpec1),
   true = maps:is_key(Name1, JsonDefinitions),
   true = maps:is_key(Name2, JsonDefinitions),
+
+  {comment, ""}.
+
+-spec add_definition_array_test(Config::cowboy_swagger_test_utils:config()) ->
+  {comment, string()}.
+add_definition_array_test(_Config) ->
+  %%
+  %% Given
+  %%
+  ct:comment("Add first definition"),
+  Name1 = <<"CostumerDefinition">>,
+  Properties1 = test_properties_one(),
+
+  ct:comment("Add second definition"),
+  Name2 = <<"CarDefinition">>,
+  Properties2 = test_properties_two(),
+
+  %%
+  %% When
+  %%
+  ok = cowboy_swagger:add_definition_array(Name1, Properties1),
+  ok = cowboy_swagger:add_definition_array(Name2, Properties2),
+
+  %%
+  %% Then
+  %%
+  {ok, SwaggerSpec1} = application:get_env(cowboy_swagger, global_spec),
+  JsonDefinitions = maps:get(definitions, SwaggerSpec1),
+  true = maps:is_key(items, maps:get(Name1, JsonDefinitions)),
+  true = maps:is_key(items, maps:get(Name2, JsonDefinitions)),
+  <<"array">> = maps:get(type, maps:get(Name1, JsonDefinitions)),
+  <<"array">> = maps:get(type, maps:get(Name2, JsonDefinitions)),
 
   {comment, ""}.
 
@@ -260,3 +284,28 @@ test_trails() ->
    trails:trail("/a/:b/[:c]", handler2, [], Metadata),
    trails:trail("/a", handler3, [], Metadata1)|
    cowboy_swagger_handler:trails()].
+
+test_properties_one() ->
+  #{ <<"first_name">> =>
+      #{ type => <<"string">>
+       , description => <<"User first name">>
+       , example => <<"Pepito">>
+       }
+   , <<"last_name">> =>
+      #{ type => <<"string">>
+       , description => <<"User last name">>
+       , example => <<"Perez">>
+       }
+   }.
+
+test_properties_two() ->
+  #{ <<"brand">> =>
+      #{ type => <<"string">>
+       , description => <<"Car brand">>
+       }
+   , <<"year">> =>
+      #{ type => <<"string">>
+       , description => <<"Production time">>
+       , example => <<"1995">>
+       }
+   }.


### PR DESCRIPTION
Currently, `add_definition/2` hardcodes the the type `<<"object">>`. It's annoying when I have response as a list of objects such as `[{"apple": 1, "banana": 2}, {"apple": 3, "banana": 4}, ...]` ([Swagger Data Types: Arrays](https://swagger.io/docs/specification/data-models/data-types/#array))

Currently I have to write this:
```erlang
DefinitionName = <<"my_basket">>,
DefinitionProperties =
  #{ apple => #{ type => "string"}
   , banana => #{ type => "string"}
   },
ok = cowboy_swagger:add_definition(DefinitionName, DefinitionProperties),
[...]
, responses =>
    #{ <<"200">> =>
      #{ description => "Gets echo var from the server 200 OK"
       , schema =>
           #{ type => <<"array">>
            , items =>  cowboy_swagger:schema(<<"my_basket">>)
            }
```
With `add_definition_array/2` I can just simply do this:
```erlang
DefinitionName = <<"my_basket">>,
DefinitionProperties =
  #{ apple => #{ type => "string"}
   , banana => #{ type => "string"}
   },
ok = cowboy_swagger:add_definition_array(DefinitionName, DefinitionProperties),
...
, responses =>
    #{ <<"200">> =>
      #{ description => "Gets echo var from the server 200 OK"
       , schema => cowboy_swagger:schema(<<"my_basket">>)
       }
     }
```