### PR TITLE
Support 'components' section in openapi 3.0.0

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -69,10 +69,8 @@
 -type metadata() :: trails:metadata(swagger_map()).
 -export_type([swagger_map/0, metadata/0]).
 
--define(SWAGGER_2_0, swagger_2_0).
--define(OPENAPI_3_0_0, openapi_3_0_0).
--type swagger_version() :: ?SWAGGER_2_0
-                         | ?OPENAPI_3_0_0.
+-type swagger_version() :: swagger_2_0
+                         | openapi_3_0_0.
 -export_type([swagger_version/0]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -124,9 +122,9 @@ add_definition(Definition) ->
   map().
 schema(DefinitionName) ->
   case swagger_version() of
-    ?SWAGGER_2_0 ->
+    swagger_2_0 ->
       #{<<"$ref">> => <<"#/definitions/", DefinitionName/binary>>};
-    ?OPENAPI_3_0_0 ->
+    openapi_3_0_0 ->
       #{<<"$ref">> => <<"#/components/schemas/", DefinitionName/binary>>}
   end.
 
@@ -173,9 +171,9 @@ filter_cowboy_swagger_handler(Trails) ->
               | parameters_definition_array().
 get_existing_definitions(CurrentSpec) ->
   case swagger_version() of
-    ?SWAGGER_2_0 ->
+    swagger_2_0 ->
       maps:get(definitions, CurrentSpec, #{});
-    ?OPENAPI_3_0_0 ->
+    openapi_3_0_0 ->
       case CurrentSpec of
         #{components :=
             #{schemas := Schemas }} -> Schemas;
@@ -191,9 +189,9 @@ get_existing_definitions(CurrentSpec) ->
 -spec swagger_version() -> swagger_version().
 swagger_version() ->
   case application:get_env(cowboy_swagger, global_spec, #{}) of
-    #{openapi := "3.0.0"} -> ?OPENAPI_3_0_0;
-    #{swagger := "2.0"}   -> ?SWAGGER_2_0;
-    _Other                -> ?SWAGGER_2_0
+    #{openapi := "3.0.0"} -> openapi_3_0_0;
+    #{swagger := "2.0"}   -> swagger_2_0;
+    _Other                -> swagger_2_0
   end.
 
 %% @private
@@ -307,10 +305,10 @@ build_definition_array(Name, Properties) ->
   NewSpec :: map().
 prepare_new_global_spec(CurrentSpec, Definitions) ->
   case swagger_version() of
-    ?SWAGGER_2_0 ->
+    swagger_2_0 ->
       CurrentSpec#{definitions => Definitions
                   };
-    ?OPENAPI_3_0_0 ->
+    openapi_3_0_0 ->
       CurrentSpec#{components =>
                     #{ schemas => Definitions
                      }

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -8,6 +8,7 @@
 -export([enc_json/1, dec_json/1]).
 -export([swagger_paths/1, validate_metadata/1]).
 -export([filter_cowboy_swagger_handler/1]).
+-export([get_existing_definitions/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Types.
@@ -68,6 +69,12 @@
 -type metadata() :: trails:metadata(swagger_map()).
 -export_type([swagger_map/0, metadata/0]).
 
+-define(SWAGGER_2_0, swagger_2_0).
+-define(OPENAPI_3_0_0, openapi_3_0_0).
+-type swagger_version() :: ?SWAGGER_2_0
+                         | ?OPENAPI_3_0_0.
+-export_type([swagger_version/0]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Public API.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -107,16 +114,21 @@ add_definition(Name, Properties) ->
   ok.
 add_definition(Definition) ->
   CurrentSpec = application:get_env(cowboy_swagger, global_spec, #{}),
-  ExistingDefinitions = maps:get(definitions, CurrentSpec, #{}),
-  NewSpec = CurrentSpec#{definitions => maps:merge( ExistingDefinitions
-                                                  , Definition
-                                                  )},
+  NewDefinitions = maps:merge( get_existing_definitions(CurrentSpec)
+                             , Definition
+                             ),
+  NewSpec = prepare_new_global_spec(CurrentSpec, NewDefinitions),
   application:set_env(cowboy_swagger, global_spec, NewSpec).
 
 -spec schema(DefinitionName::parameter_definition_name()) ->
   map().
 schema(DefinitionName) ->
-  #{<<"$ref">> => <<"#/definitions/", DefinitionName/binary>>}.
+  case swagger_version() of
+    ?SWAGGER_2_0 ->
+      #{<<"$ref">> => <<"#/definitions/", DefinitionName/binary>>};
+    ?OPENAPI_3_0_0 ->
+      #{<<"$ref">> => <<"#/components/schemas/", DefinitionName/binary>>}
+  end.
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -156,9 +168,33 @@ filter_cowboy_swagger_handler(Trails) ->
   end,
   lists:filter(F, Trails).
 
+-spec get_existing_definitions(CurrentSpec :: map()) ->
+  Definition :: parameters_definitions()
+              | parameters_definition_array().
+get_existing_definitions(CurrentSpec) ->
+  case swagger_version() of
+    ?SWAGGER_2_0 ->
+      maps:get(definitions, CurrentSpec, #{});
+    ?OPENAPI_3_0_0 ->
+      case CurrentSpec of
+        #{components :=
+            #{schemas := Schemas }} -> Schemas;
+        _Other                      -> #{}
+      end
+  end.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Private API.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% @private
+-spec swagger_version() -> swagger_version().
+swagger_version() ->
+  case application:get_env(cowboy_swagger, global_spec, #{}) of
+    #{openapi := "3.0.0"} -> ?OPENAPI_3_0_0;
+    #{swagger := "2.0"}   -> ?SWAGGER_2_0;
+    _Other                -> ?SWAGGER_2_0
+  end.
 
 %% @private
 is_visible(_Method, Metadata) ->
@@ -263,3 +299,20 @@ build_definition_array(Name, Properties) ->
                          }
              }}.
 
+%% @private
+-spec prepare_new_global_spec( CurrentSpec :: map()
+                             , Definitions :: parameters_definitions()
+                                            | parameters_definition_array()
+                             ) ->
+  NewSpec :: map().
+prepare_new_global_spec(CurrentSpec, Definitions) ->
+  case swagger_version() of
+    ?SWAGGER_2_0 ->
+      CurrentSpec#{definitions => Definitions
+                  };
+    ?OPENAPI_3_0_0 ->
+      CurrentSpec#{components =>
+                    #{ schemas => Definitions
+                     }
+                  }
+  end.

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -12,6 +12,7 @@
 -export([ to_json_test/1
         , add_definition_test/1
         , add_definition_array_test/1
+        , schema_test/1
         ]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -138,6 +139,42 @@ to_json_test(_Config) ->
 -spec add_definition_test(Config::cowboy_swagger_test_utils:config()) ->
   {comment, string()}.
 add_definition_test(_Config) ->
+  set_swagger_version(swagger_2_0),
+  perform_add_definition_test(),
+
+  set_swagger_version(openapi_3_0_0),
+  perform_add_definition_test(),
+
+  {comment, ""}.
+
+-spec add_definition_array_test(Config::cowboy_swagger_test_utils:config()) ->
+  {comment, string()}.
+add_definition_array_test(_Config) ->
+  set_swagger_version(swagger_2_0),
+  perform_add_definition_array_test(),
+
+  set_swagger_version(openapi_3_0_0),
+  perform_add_definition_array_test(),
+
+  {comment, ""}.
+
+-spec schema_test(Config::cowboy_swagger_test_utils:config()) ->
+  {comment, string()}.
+schema_test(_Config) ->
+  set_swagger_version(swagger_2_0),
+  #{<<"$ref">> := <<"#/definitions/Pet">>} = cowboy_swagger:schema(<<"Pet">>),
+
+  set_swagger_version(openapi_3_0_0),
+  #{<<"$ref">> := <<"#/components/schemas/Pet">>} = cowboy_swagger:schema(<<"Pet">>),
+
+  {comment, ""}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Internal functions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% @private
+perform_add_definition_test() ->
   %%
   %% Given
   %%
@@ -162,12 +199,10 @@ add_definition_test(_Config) ->
   JsonDefinitions = cowboy_swagger:get_existing_definitions(SwaggerSpec1),
   true = maps:is_key(Name1, JsonDefinitions),
   true = maps:is_key(Name2, JsonDefinitions),
+  ok.
 
-  {comment, ""}.
-
--spec add_definition_array_test(Config::cowboy_swagger_test_utils:config()) ->
-  {comment, string()}.
-add_definition_array_test(_Config) ->
+%% @private
+perform_add_definition_array_test() ->
   %%
   %% Given
   %%
@@ -194,12 +229,7 @@ add_definition_array_test(_Config) ->
   true = maps:is_key(items, maps:get(Name2, JsonDefinitions)),
   <<"array">> = maps:get(type, maps:get(Name1, JsonDefinitions)),
   <<"array">> = maps:get(type, maps:get(Name2, JsonDefinitions)),
-
-  {comment, ""}.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Internal functions
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  ok.
 
 %% @private
 test_trails() ->
@@ -285,6 +315,7 @@ test_trails() ->
    trails:trail("/a", handler3, [], Metadata1)|
    cowboy_swagger_handler:trails()].
 
+%% @private
 test_properties_one() ->
   #{ <<"first_name">> =>
       #{ type => <<"string">>
@@ -298,6 +329,7 @@ test_properties_one() ->
        }
    }.
 
+%% @private
 test_properties_two() ->
   #{ <<"brand">> =>
       #{ type => <<"string">>
@@ -309,3 +341,11 @@ test_properties_two() ->
        , example => <<"1995">>
        }
    }.
+
+%% @private
+set_swagger_version(swagger_2_0) ->
+  Spec0 = maps:remove(openapi, application:get_env(cowboy_swagger, global_spec, #{})),
+  application:set_env(cowboy_swagger, global_spec, Spec0#{swagger => "2.0"});
+set_swagger_version(openapi_3_0_0) ->
+  Spec0 = maps:remove(swagger, application:get_env(cowboy_swagger, global_spec, #{})),
+  application:set_env(cowboy_swagger, global_spec, Spec0#{openapi => "3.0.0"}).

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -159,7 +159,7 @@ add_definition_test(_Config) ->
   %% Then
   %%
   {ok, SwaggerSpec1} = application:get_env(cowboy_swagger, global_spec),
-  JsonDefinitions = maps:get(definitions, SwaggerSpec1),
+  JsonDefinitions = cowboy_swagger:get_existing_definitions(SwaggerSpec1),
   true = maps:is_key(Name1, JsonDefinitions),
   true = maps:is_key(Name2, JsonDefinitions),
 
@@ -189,7 +189,7 @@ add_definition_array_test(_Config) ->
   %% Then
   %%
   {ok, SwaggerSpec1} = application:get_env(cowboy_swagger, global_spec),
-  JsonDefinitions = maps:get(definitions, SwaggerSpec1),
+  JsonDefinitions = cowboy_swagger:get_existing_definitions(SwaggerSpec1),
   true = maps:is_key(items, maps:get(Name1, JsonDefinitions)),
   true = maps:is_key(items, maps:get(Name2, JsonDefinitions)),
   <<"array">> = maps:get(type, maps:get(Name1, JsonDefinitions)),


### PR DESCRIPTION
Currently, `add_definition/1` always adds to the `definitions:` section in swagger.json and `schema/1` hardcodes to fetch from `<<"#/definitions/", DefinitionName/binary>>`.

Open API 3.0.0 has removed the `#/definitions/` section and [introduced](https://blog.readme.com/an-example-filled-guide-to-swagger-3-2/) `#/components/schemas/` ([Components Section](https://swagger.io/docs/specification/components/))

```
OpenAPI 2.0                    OpenAPI 3.0
'#/definitions/User'         → '#/components/schemas/User'
```
This causes:
```
Structural error at 
should NOT have additional properties
additionalProperty: definitions
Jump to line 0
 ```
This PR adds support to point `add_definition/1` and `schema/1` to "components" section if `openapi: "3.0.0"` is defined. For `swagger: "2.0"`, it will still add to "definitions" section.