### PR TITLE
basePath & servers support; support more schema type 

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -150,7 +150,12 @@ dec_json(Data) ->
 %% @hidden
 -spec swagger_paths([trails:trail()]) -> map().
 swagger_paths(Trails) ->
-  swagger_paths(Trails, #{}).
+  swagger_paths(Trails, undefined).
+
+-spec swagger_paths([trails:trail()], binary() | string() | undefined) -> map().
+swagger_paths(Trails, BasePath) ->
+    Paths = trans_swagger_paths(Trails, #{}),
+    refactor_base_path(Paths, BasePath).
 
 %% @hidden
 -spec validate_metadata(trails:metadata(_)) -> metadata().
@@ -199,12 +204,37 @@ is_visible(_Method, Metadata) ->
   not maps:get(hidden, Metadata, false).
 
 %% @private
-swagger_paths([], Acc) ->
+trans_swagger_paths([], Acc) ->
   Acc;
-swagger_paths([Trail | T], Acc) ->
+trans_swagger_paths([Trail | T], Acc) ->
   Path = normalize_path(trails:path_match(Trail)),
   Metadata = normalize_map_values(validate_metadata(trails:metadata(Trail))),
-  swagger_paths(T, maps:put(Path, Metadata, Acc)).
+  trans_swagger_paths(T, maps:put(Path, Metadata, Acc)).
+
+%% @private
+refactor_base_path(PathMap, undefined) ->
+  PathMap;
+refactor_base_path(PathMap, BasePath) when is_list(BasePath) ->
+  refactor_base_path(PathMap, list_to_binary(BasePath));
+refactor_base_path(PathMap, BasePath) ->
+  Fun =
+    fun(Path, NextPathMap) ->
+      maps:put(remove_base_path(Path, BasePath), maps:get(Path, PathMap), NextPathMap)
+    end,
+  lists:foldl(Fun, #{}, maps:keys(PathMap)).
+
+%% /base_path/api -> /api
+%% @private
+-spec(remove_base_path(binary(), binary()) -> binary()).
+remove_base_path(Path, BasePath) ->
+  BasePathLength = erlang:size(BasePath),
+  MatchLength = BasePathLength + 1,
+  case binary:match(Path, <<BasePath/binary, "/">>) of
+    {0, MatchLength} ->
+      binary:part(Path, BasePathLength, erlang:size(Path) - BasePathLength);
+    _ ->
+      Path
+  end.
 
 %% @private
 normalize_path(Path) ->
@@ -246,11 +276,21 @@ normalize_list_values(List) ->
 
 %% @private
 create_swagger_spec(#{swagger := _Version} = GlobalSpec, SanitizeTrails) ->
-    GlobalSpec#{paths => swagger_paths(SanitizeTrails)};
+  BasePath =  maps:get(basePath, GlobalSpec, undefined),
+  SwaggerPaths = swagger_paths(SanitizeTrails, BasePath),
+  GlobalSpec#{paths => SwaggerPaths};
 create_swagger_spec(#{openapi := _Version} = GlobalSpec, SanitizeTrails) ->
-  GlobalSpec#{paths => swagger_paths(SanitizeTrails)};
+  BasePath = deconstruct_openapi_url(GlobalSpec),
+  SwaggerPaths = swagger_paths(SanitizeTrails, BasePath),
+  GlobalSpec#{paths => SwaggerPaths};
 create_swagger_spec(GlobalSpec, SanitizeTrails) ->
   create_swagger_spec(GlobalSpec#{openapi => <<"3.0.0">>}, SanitizeTrails).
+
+%% @private
+deconstruct_openapi_url(GlobalSpec) ->
+    Servers = maps:get(servers, GlobalSpec, [#{}]),
+    Url = maps:get(url, hd(Servers), <<"">>),
+    maps:get(path, uri_string:parse(Url)).
 
 %% @private
 validate_swagger_map(Map) ->

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -289,8 +289,8 @@ create_swagger_spec(GlobalSpec, SanitizeTrails) ->
 
 %% @private
 deconstruct_openapi_url(GlobalSpec) ->
-    Servers = maps:get(servers, GlobalSpec, [#{}]),
-    Url = maps:get(url, hd(Servers), <<"">>),
+    [Server|_] = maps:get(servers, GlobalSpec, [#{}]),
+    Url = maps:get(url, Server, <<"">>),
     maps:get(path, uri_string:parse(Url)).
 
 %% @private

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -1,6 +1,7 @@
 %%% @doc cowboy-swagger main interface.
 -module(cowboy_swagger).
 
+-ignore_xref([{?MODULE, add_definition, 1}]).
 %% API
 -export([to_json/1, add_definition/1, add_definition/2, add_definition_array/2, schema/1]).
 
@@ -154,7 +155,7 @@ swagger_paths(Trails) ->
 
 -spec swagger_paths([trails:trail()], binary() | string() | undefined) -> map().
 swagger_paths(Trails, BasePath) ->
-    Paths = trans_swagger_paths(Trails, #{}),
+    Paths = translate_swagger_paths(Trails, #{}),
     refactor_base_path(Paths, BasePath).
 
 %% @hidden
@@ -204,12 +205,12 @@ is_visible(_Method, Metadata) ->
   not maps:get(hidden, Metadata, false).
 
 %% @private
-trans_swagger_paths([], Acc) ->
+translate_swagger_paths([], Acc) ->
   Acc;
-trans_swagger_paths([Trail | T], Acc) ->
+translate_swagger_paths([Trail | T], Acc) ->
   Path = normalize_path(trails:path_match(Trail)),
   Metadata = normalize_map_values(validate_metadata(trails:metadata(Trail))),
-  trans_swagger_paths(T, maps:put(Path, Metadata, Acc)).
+  translate_swagger_paths(T, maps:put(Path, Metadata, Acc)).
 
 %% @private
 refactor_base_path(PathMap, undefined) ->

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -351,8 +351,9 @@ prepare_new_global_spec(CurrentSpec, Definitions) ->
       CurrentSpec#{definitions => Definitions
                   };
     openapi_3_0_0 ->
+      Components = maps:get(components, CurrentSpec, #{}),
       CurrentSpec#{components =>
-                    #{ schemas => Definitions
+                        Components#{ schemas => Definitions
                      }
                   }
   end.

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -2,7 +2,7 @@
 -module(cowboy_swagger).
 
 %% API
--export([to_json/1, add_definition/2, add_definition_array/2, schema/1]).
+-export([to_json/1, add_definition/1, add_definition/2, add_definition_array/2, schema/1]).
 
 %% Utilities
 -export([enc_json/1, dec_json/1]).

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -211,7 +211,7 @@ perform_add_completed_definition_test() ->
   JsonDefinitions = cowboy_swagger:get_existing_definitions(SwaggerSpec1),
   true = maps:is_key(Name1, JsonDefinitions),
   true = maps:is_key(Name2, JsonDefinitions),
-  ok.
+  {comment, ""}.
 
 %% @private
 perform_add_definition_test() ->

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -211,7 +211,7 @@ perform_add_completed_definition_test() ->
   JsonDefinitions = cowboy_swagger:get_existing_definitions(SwaggerSpec1),
   true = maps:is_key(Name1, JsonDefinitions),
   true = maps:is_key(Name2, JsonDefinitions),
-  {comment, ""}.
+  ok.
 
 %% @private
 perform_add_definition_test() ->


### PR DESCRIPTION
fixed: https://github.com/inaka/cowboy_swagger/issues/134

support more schema, as like open api 3.0.0:
```erlang
#{
        allOf => [
            #{
                type => object,
                required => [name],
                properties => #{
                    name => #{
                        type => string,
                        example => "exmaple"
                    }
                }
            },
            #{
                oneOf => [ cowboy_swagger:schema(<<"password_based">>)
                                 , cowboy_swagger:schema(<<"jwt">>)
                                 , cowboy_swagger:schema(<<"scram">>)
                ]    
            }
        ]
    },

``` 
