### PR TITLE
Add "-" and "_" for path binding variable names format

### DIFF
--- a/example/src/example_echo_handler.erl
+++ b/example/src/example_echo_handler.erl
@@ -31,12 +31,12 @@ trails() ->
               #{tags => ["echo"],
                 description => "Sets echo var in the server",
                 parameters =>
-                    [#{name => <<"echo">>,
+                    [#{name => <<"echo-kebab_case">>,
                        description => <<"Echo message">>,
                        in => <<"path">>,
                        required => false,
                        schema => #{type => string, example => <<"Hello, World!">>}}]}},
-    [trails:trail("/message/[:echo]", example_echo_handler, [], Metadata)].
+    [trails:trail("/message/[:echo-kebab_case]", example_echo_handler, [], Metadata)].
 
 %% cowboy
 allowed_methods(Req, State) ->
@@ -49,7 +49,7 @@ handle_get(Req, State) ->
     {Body, Req, State}.
 
 handle_put(Req, State) ->
-    Echo = cowboy_req:binding(echo, Req, ""),
+    Echo = cowboy_req:binding('echo-kebab_case', Req, ""),
     application:set_env(example, echo, Echo),
     Body = [<<"You put an echo! ">>, Echo],
     Req1 = cowboy_req:set_resp_body(Body, Req),

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -332,7 +332,7 @@ remove_base_path(Path, BasePath) ->
 %% @private
 normalize_path(Path) ->
     re:replace(
-        re:replace(Path, "\\:[a-zA-Z0-9_][a-zA-Z0-9-_]*", "\\{&\\}", [global]),
+        re:replace(Path, "\\:\\w[\\w-]*", "\\{&\\}", [global]),
         "\\[|\\]|\\:",
         "",
         [{return, binary}, global]).

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -332,7 +332,7 @@ remove_base_path(Path, BasePath) ->
 %% @private
 normalize_path(Path) ->
     re:replace(
-        re:replace(Path, "\\:\\w+", "\\{&\\}", [global]),
+        re:replace(Path, "\\:[a-zA-Z0-9_][a-zA-Z0-9-_]*", "\\{&\\}", [global]),
         "\\[|\\]|\\:",
         "",
         [{return, binary}, global]).


### PR DESCRIPTION
Our API specification comes in a yaml file containing OpenAPI definitions. We generate our trails definitions from these yaml file. Openapi does not restrict the naming of path parameters, it shall be a string without /?#. (see https://spec.openapis.org/oas/latest.html#path-templating). Our customers started to use '-' in path parameter field names. We would avoid to parse and generate field names for bindings in our handlers for cowboy. Cowboy and trails works fine with the 'extension' our swagger page generated from the trails definitions does not work as it compiles "/customers/[:customer-name]" to "/customers/{customer}-name" and cannot be used to test the endpoint from the generated swagger page.