### PR TITLE
Be less wasteful of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 ---
 name: build
-on: [push, pull_request]
+on: [push]
 jobs:
   ci:
     name: Run checks and tests over ${{matrix.otp_vsn}}


### PR DESCRIPTION
Don't repeat steps for CI. A pull request action is typically a push, already.